### PR TITLE
Remove GPU acceleration

### DIFF
--- a/chat.simplex.simplex.yml
+++ b/chat.simplex.simplex.yml
@@ -9,7 +9,6 @@ build-options:
   no-debuginfo: true
   no-debuginfo-compression: true
 finish-args:
-  - --device=dri
   - --share=ipc
   - --share=network
   - --socket=x11


### PR DESCRIPTION
The app seems to run fine with GPU acceleration disabled. GPU drivers are proprietary and introduce a lot of attack surface, and because of how little competition there is in the GPU market, there aren't significant commercial consequences for GPU manufacturers that are careless with security.

Given the very high security requirements for SimpleX, I think it's ideal to disable GPU acceleration unless there's a serious issue with functionality/performance that I'm not aware of. 

Before the Zerodium website basically became defunct, they were paying up to $500,000 for a zero-click Signal RCE and $1,500,000 for a zero-click WhatsApp RCE, and they claimed to have received over 1,500 submissions from 2,000 researchers and paid over $100,000,000 in bounties. Meanwhile, the NSO Group has spent years defending a lawsuit just so they can be legally allowed to hack WhatsApp.

There's a very big market for the ability to compromise messaging apps, and so I think minimizing attack surface as much as possible is important.